### PR TITLE
Updates to CrawlerESUploader and Update NCBIGeo, ImmPort to use CrawlerESUploader

### DIFF
--- a/crawler/upload/__init__.py
+++ b/crawler/upload/__init__.py
@@ -232,8 +232,6 @@ class DataMetadata:
         }
 
 
-
-
 class CrawlerIndices:
 
     def __init__(self, client, mappings=None, settings=None):
@@ -270,4 +268,6 @@ class CrawlerIndices:
 
         return self.client.index(index=_index, id=_id, body=_source)
 
+
 from .zenodo_covid import ZenodoCovidUploader
+from .immport import ImmPortUploader

--- a/crawler/upload/__init__.py
+++ b/crawler/upload/__init__.py
@@ -99,7 +99,7 @@ class CrawlerESUploader:
         Modify documents after the quick transform phase.
         """
         # override here
-        raise NotImplementedError
+        return doc
 
 
 class CrawlerDatasetESUploader(CrawlerESUploader):

--- a/crawler/upload/__init__.py
+++ b/crawler/upload/__init__.py
@@ -271,3 +271,4 @@ class CrawlerIndices:
 
 from .zenodo_covid import ZenodoCovidUploader
 from .immport import ImmPortUploader
+from .ncbi_geo import NCBIGeoUploader

--- a/crawler/upload/__init__.py
+++ b/crawler/upload/__init__.py
@@ -183,7 +183,7 @@ class DataReindex:
             'name': 'cyclin dependent kinase 2
         }
         """
-        for doc in scan(self.src_client, index=self.src_index):
+        for doc in scan(self.src_client, index=self.src_index, scroll="5m", size=30):
             _doc = {'_id': doc['_id']}
             _doc.update(doc['_source'])
             yield _doc

--- a/crawler/upload/__init__.py
+++ b/crawler/upload/__init__.py
@@ -11,9 +11,12 @@ To make the crawled items searchable and aggregatable, reindexing is necessary.
 from datetime import datetime
 import logging
 import os
+from typing import Union
 
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import reindex, scan
+
+from .tdoc import TransformDoc
 
 
 uploaders = {
@@ -25,17 +28,6 @@ uploaders = {
 class CrawlerESUploader:
 
     NAME = 'default'
-
-    #---------------------------#
-    #        Transform          #
-    #---------------------------#
-
-    TRANSFORM_KEYS = {
-        # "<original_field_name>": "<new_field_name>"
-    }
-    TRANSFORM_VALUES = {
-        # "<field_name>": lambda value: f(value)
-    }
 
     #---------------------------#
     #           Index           #
@@ -60,10 +52,8 @@ class CrawlerESUploader:
     BIOTHING_VERSION = 'c1.0'
 
     def __init__(self, **kwargs):
-
         self.metadata = DataMetadata(self)
         self.indexing = DataReindex(self, **kwargs)
-        self.transform = DataTransform(self)
 
     def __init_subclass__(cls):
         super().__init_subclass__()
@@ -75,22 +65,14 @@ class CrawlerESUploader:
         This is primarily how to interact with this class.
         """
         # reindex as-is
-        if not any((
-            self.TRANSFORM_KEYS,
-            self.TRANSFORM_VALUES,
-            self.INDEX_MAPPINGS
-        )) and all((
-            self.extract_id is CrawlerESUploader.extract_id,
-            self.transform_doc is CrawlerESUploader.transform_doc
-        )):
+        if not self.INDEX_MAPPINGS and self.extract_id is CrawlerESUploader.extract_id:
             self.indexing.reindex()
             return
 
         # apply transformation
         for doc in self.indexing.scan():
             _id = self.extract_id(doc)
-            _source = self.transform.quick_transform(doc)
-            _source = self.transform_doc(_source)
+            _source = self.transform_doc(TransformDoc(doc))
             self.indexing.index(_id, _source)
 
     def extract_id(self, doc):
@@ -112,12 +94,12 @@ class CrawlerESUploader:
         """
         return doc.pop('_id', None)
 
-    def transform_doc(self, doc):
+    def transform_doc(self, doc: TransformDoc) -> dict:
         """
         Modify documents after the quick transform phase.
         """
         # override here
-        return doc
+        raise NotImplementedError
 
 
 class CrawlerDatasetESUploader(CrawlerESUploader):
@@ -133,45 +115,6 @@ class CrawlerDatasetESUploader(CrawlerESUploader):
         }
         base.update(doc)
         return base
-
-
-class DataTransform:
-
-    def __init__(self, uploader):
-        self.uploader = uploader
-
-    def quick_transform(self, doc):
-        """
-        Apply dictionay key, value transformations.
-        Find transformation settings in the uploader instance.
-        """
-        doc = self._transform_names(doc, self.uploader.TRANSFORM_KEYS)
-        doc = self._transform_values(doc, self.uploader.TRANSFORM_VALUES)
-        return doc
-
-    def schema_transform(self, doc):
-        # the method above is to modify the original document,
-        # this could be by defining how the new one should look,
-        # ideally the definition in this manner is more readable.
-        raise NotImplementedError()
-
-    def _transform_names(self, doc, mappings):
-        _doc = {}
-        for key in doc:
-            if key in mappings:
-                _doc[mappings[key]] = doc[key]
-            else:
-                _doc[key] = doc[key]
-        return _doc
-
-    def _transform_values(self, doc, mapping_funcs):
-        _doc = {}
-        for key in doc:
-            if key in mapping_funcs:
-                _doc[key] = mapping_funcs[key](_doc[key])
-            else:
-                _doc[key] = doc[key]
-        return _doc
 
 
 class DataReindex:

--- a/crawler/upload/helper.py
+++ b/crawler/upload/helper.py
@@ -29,7 +29,7 @@ def pmid_to_funding(pmid):
     Use Pubmed ID to find funding information objects
     '''
     url = "https://www.ncbi.nlm.nih.gov/pubmed/" + pmid
-    body = requests.get(url).text
+    body = requests.get(url, timeout=5).text
     pattern = '//*[@id="maincontent"]/div/div[5]/div/div/div/div//h4'
     sections = Selector(text=body).xpath(pattern)
 
@@ -108,7 +108,7 @@ def pmid_to_citation(pmid):
     Use pmid to find citation string
     '''
     url = 'https://www.ncbi.nlm.nih.gov/sites/PubmedCitation?id=' + pmid
-    body = requests.get(url).text
+    body = requests.get(url, timeout=5).text
     citation = Selector(text=body).xpath('string(/)').get()
     return citation.replace(u'\xa0', u' ')
 

--- a/crawler/upload/ncbi_geo.py
+++ b/crawler/upload/ncbi_geo.py
@@ -8,104 +8,58 @@
     May include a number, or numbers separated by ', '.
 """
 
-### TODO NEED TO RESTRUCTRUE
 
 import logging
 import os
 import time
 
-from elasticsearch_dsl import Search
-from elasticsearch_dsl.connections import connections
-
-from helper import (pmid_to_citation, pmid_to_funding, pmid_with_eutils,
-                    transform)
-
-connections.create_connection(hosts=['localhost:9199'])
-import asyncio
-import logging
-
-from elasticsearch import Elasticsearch
-from elasticsearch_dsl import Search, Document
-from elasticsearch_dsl.serializer import serializer
-from web.index import transform
-
-client = Elasticsearch('localhost:9200', serializer=serializer)
+from . import CrawlerESUploader
+from .helper import pmid_to_citation, pmid_to_funding, pmid_with_eutils
 
 
+class NCBIGeoUploader(CrawlerESUploader):
+    NAME = 'ncbi_geo'
+    BIOTHING_TYPE = 'dataset'  # TODO: is this the proper type?
+    BIOTHING_VERSION = 'c1.0'
 
+    # keep default settings
+    # INDEX_SETTINGS = {}
+    # INDEX_MAPPINGS = {}
 
-async def structure_ncbi_geo():
-    global count
-    search = Search(using=client, index='ncbi_geo_transformed')
-    search = search.params(scroll='1d', sort=['_id'])
-    for doc in search.scan():
-        if 'funding' in doc:
-            new_list = []
-            for funding in doc.funding:
-                if funding['funder']['name'] and len(funding['identifier']) > 3:
-                    new_list.append(funding)
-            logging.info("%s -> %s", len(doc.funding), len(new_list))
-            if not new_list:
-                new_list = None
-            client.update(
-                index='ncbi_geo_transformed',
-                id=doc.meta.id,
-                body={
-                    "doc": {
-                        "funding": new_list}})
+    def extract_id(self, doc):
+        # the _id is left in the document
+        return 'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=' + doc['_id']
 
+    def transform_doc(self, doc):
+        # Update document using transforms
+        doc = doc.transform_keys_values({
+            "Contributor(s)": lambda value: {
+                "creator": [{
+                    "@type": "Person",
+                    "name": individual
+                } for individual in value.split(', ')]
+            },
+            "Organization": lambda value: {
+                "publisher": {
+                    "@type": "Organization",
+                    "name": value
+                }
+            }
+        }, ignore_key_error=True).rename_keys({
+            "Title": "name",
+            "Organism": "organism",
+            "Experiment type": "measurementTechnique",
+            "Summary": "description",
+            "Submission date": "datePublished",
+            "Last update date": "dateModified",
+        }, ignore_key_error=True)
 
-logging.basicConfig(level='INFO')
-loop = asyncio.get_event_loop()
-loop.run_until_complete(structure_ncbi_geo())
-
-NCBI_MAPPINGS = {
-    "Title": "name",
-    "Organism": "organism",
-    "Experiment type": "measurementTechnique",
-    "Summary": "description",
-    "Contributor(s)": lambda value: {
-        "creator": [{
-            "@type": "Person",
-            "name": individual
-        } for individual in value.split(', ')]
-    },
-    "Submission date": "datePublished",
-    "Last update date": "dateModified",
-    "Organization": lambda value: {
-        "publisher": {
-            "@type": "Organization",
-            "name": value
-        }
-    }
-}
-
-
-def main():
-    client = connections.get_connection()
-    search = Search(index='ncbi_geo')
-
-    for doc in search.params(scroll='1d').scan(): # pylint: disable=no-member
-
-        _id = doc.meta.id
-        dic = doc.to_dict()
-
+        # Perform additional changes
+        _id = doc.pop('_id')  # obtain and remove this from the original document
         url = 'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=' + _id
-
-        # if not client.exists(index='ncbi_geo_transformed', id=_id):
-
-        logging.info('%s', _id)
-
-        ### Transform data fields ###
-
-        try:
-            doc = transform(dic, NCBI_MAPPINGS)
-        except Exception as e:
-            logging.warning(e)
-
-        ### Add metadata fixtures ###
-
         meta = {
+            "@context": "http://schema.org/",
+            "@type": "Dataset",
             "identifier": _id,
             "distribution": {
                 "@type": "dataDownload",
@@ -119,34 +73,25 @@ def main():
         }
         doc.update(meta)
 
-        if 'Citation(s)' in dic:
-
+        if 'Citation(s)' in doc:
             if 'API_KEY' in os.environ:
-
                 funding = []
                 citations = []
-
-                for pmid in dic['Citation(s)'].split(','):
+                for pmid in doc['Citation(s)'].split(','):
                     pmid = pmid.strip()
                     grants, citation = pmid_with_eutils(pmid)
                     funding += grants
                     citations.append(citation)
-
                 if funding:
                     doc['funding'] = funding
-
                 if citations:
                     doc['citation'] = citations
-
                 time.sleep(0.1)  # throttle request rates
-
             else:
-
                 ### Add funding field ###
-
                 try:
                     funding = []
-                    for pmid in dic['Citation(s)'].split(','):
+                    for pmid in doc['Citation(s)'].split(','):
                         pmid = pmid.strip()
                         funding += pmid_to_funding(pmid)
                 except Exception as e:
@@ -154,12 +99,10 @@ def main():
                 else:
                     if funding:
                         doc['funding'] = funding
-
                 ### Add citation field ###
-
                 try:
                     citations = []
-                    for pmid in dic['Citation(s)'].split(','):
+                    for pmid in doc['Citation(s)'].split(','):
                         pmid = pmid.strip()
                         citations.append(pmid_to_citation(pmid))
                 except Exception as e:
@@ -167,13 +110,28 @@ def main():
                 else:
                     if citations:
                         doc['citation'] = citations
-
                 time.sleep(0.2)  # throttle request rates
+        doc.delete_unused_keys()
+        return doc
 
-
-        client.index(index='transformed_ncbi_geo', id=url, body=doc)
-
-
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
-    main()
+# async def structure_ncbi_geo():
+#     global count
+#     search = Search(using=client, index=TARGET_INDEX)
+#     search = search.params(scroll='1d', sort=['_id'])
+#     for doc in search.scan():
+#         if 'funding' in doc:
+#             new_list = []
+#             for funding in doc.funding:
+#                 if funding['funder']['name'] and len(funding['identifier']) > 3:
+#                     new_list.append(funding)
+#             logging.info("%s -> %s", len(doc.funding), len(new_list))
+#             if not new_list:
+#                 new_list = None
+#             client.update(
+#                 index=TARGET_INDEX,
+#                 id=doc.meta.id,
+#                 body={
+#                     "doc": {
+#                         "funding": new_list}})
+# loop = asyncio.get_event_loop()
+# loop.run_until_complete(structure_ncbi_geo())

--- a/crawler/upload/ncbi_geo.py
+++ b/crawler/upload/ncbi_geo.py
@@ -1,4 +1,4 @@
-'''
+"""
     Trasnform NCBI Geo to Schema.org Structured Metadata
 
     Assume the original _id needs to be transformed
@@ -6,7 +6,7 @@
 
     'Citation(s)' field may not exist. If exist, must be str.
     May include a number, or numbers separated by ', '.
-'''
+"""
 
 ### TODO NEED TO RESTRUCTRUE
 

--- a/crawler/upload/tdoc.py
+++ b/crawler/upload/tdoc.py
@@ -1,0 +1,104 @@
+from typing import Union, Iterable, Dict, Callable, Any, Mapping
+
+
+class TransformDoc(dict):
+    """ Document dictionary with easy to use transformation helpers
+
+    """
+    def __init__(self, *args, **kwargs):
+        super(TransformDoc, self).__init__(*args, **kwargs)
+
+    def rename_keys(self, mappings: Mapping[str, str], ignore_key_error: bool = False) -> 'TransformDoc':
+        """Rename keys in a document, returning itself.
+
+        Args:
+            mappings: Keys are old keys in the document to be renamed, values are the corresponding new names.
+            ignore_key_error: Whether this method ignores when old keys does not exist, or raises `KeyError`.
+                Defaults to False, will raise `KeyError` when key does not exist.
+
+        Returns:
+            Renamed version of the same TransformDoc instance.
+
+        Raises:
+            KeyError: When `ignore_key_error` is set to false and attempting to rename a key that does not exist
+        """
+        for key in mappings.keys():
+            try:
+                self[mappings[key]] = self.pop(key)
+            except KeyError as e:
+                if ignore_key_error:
+                    pass
+                else:
+                    raise e
+        return self
+
+    def delete_keys(self, keys: Union[str, Iterable[str]], ignore_key_error: bool = True) -> 'TransformDoc':
+        """Delete keys in a document, returning itself.
+
+        Args:
+            keys: a single key name or list of key names to delete.
+            ignore_key_error: Whether this method ignores when keys does not exist, or raises `KeyError`.
+                Defaults to True, will NOT raise `KeyError` when key does not exist.
+
+        Returns:
+            Same instance of `TransformDoc` with specified keys removed.
+        """
+        for key in list(keys):
+            try:
+                del self[key]
+            except KeyError as e:
+                if ignore_key_error:
+                    pass
+                else:
+                    raise e
+        return self
+
+    def update(self, __m: Mapping[str, Any], **kwargs) -> 'TransformDoc':
+        super(TransformDoc, self).update(__m, **kwargs)
+        return self
+
+    def transform_keys_values(self, mappings: Mapping[str, Callable[[Any], Mapping[str, Any]]],
+                              ignore_key_error: bool = False) -> 'TransformDoc':
+        """Update a document using new keys and values, given old keys and functions
+
+        Args:
+            mappings: Maps old keys to functions that produces mapping containing new keys and values.
+            ignore_key_error: Whether this method ignores when old keys does not exist, or raises `KeyError`.
+                Defaults to False, will raise `KeyError` when key does not exist.
+
+        Returns:
+            Updated version of the same document.
+        """
+        for key in mappings:
+            try:
+                old_value = self.pop(key)
+                new_kv = mappings[key](old_value)
+                self.update(new_kv)
+            except KeyError as e:
+                if ignore_key_error:
+                    pass
+                else:
+                    raise e
+        return self
+
+    def transform_values(self, mappings: Dict[str, Callable[[Any], Any]],
+                         ignore_key_error: bool = False) -> 'TransformDoc':
+        """Update a document using new values, replacing old values with the same key
+
+        Args:
+            mappings: Maps old keys to functions that produces new values, to replace old values.
+            ignore_key_error: Whether this method ignores when old keys does not exist, or raises `KeyError`.
+                Defaults to False, will raise `KeyError` when key does not exist.
+
+        Returns:
+            Updated version of the same document.
+        """
+        for key in mappings:
+            try:
+                self[key] = mappings[key](self[key])
+            except KeyError as e:
+                if ignore_key_error:
+                    pass
+                else:
+                    raise e
+        return self

--- a/crawler/upload/tdoc.py
+++ b/crawler/upload/tdoc.py
@@ -1,4 +1,5 @@
-from typing import Union, Iterable, Dict, Callable, Any, Mapping
+import warnings
+from typing import Union, Iterable, Dict, Callable, Any, Mapping, Container
 
 
 class TransformDoc(dict):
@@ -7,6 +8,26 @@ class TransformDoc(dict):
     """
     def __init__(self, *args, **kwargs):
         super(TransformDoc, self).__init__(*args, **kwargs)
+        for key in self.keys():
+            if type(key) is not str:
+                v = self.pop(key)
+                self[str(key)] = v
+                warnings.warn(f"Key '{key}' is not of type str, casted to str for use in documents.", RuntimeWarning)
+        self._touched_keys = set()
+
+    def __setitem__(self, key, value):
+        super(TransformDoc, self).__setitem__(key, value)
+        self._touched_keys.add(key)
+
+    def update(self, __m: Mapping[str, Any], **kwargs) -> 'TransformDoc':
+        super(TransformDoc, self).update(__m, **kwargs)
+        for k in __m.keys():
+            self._touched_keys.add(k)
+        return self
+
+    def setdefault(self, __key, __default=...):
+        self._touched_keys.add(__key)
+        return super(TransformDoc, self).setdefault(__key, __default)
 
     def rename_keys(self, mappings: Mapping[str, str], ignore_key_error: bool = False) -> 'TransformDoc':
         """Rename keys in a document, returning itself.
@@ -53,9 +74,23 @@ class TransformDoc(dict):
                     raise e
         return self
 
-    def update(self, __m: Mapping[str, Any], **kwargs) -> 'TransformDoc':
-        super(TransformDoc, self).update(__m, **kwargs)
+    def delete_keys_except(self, keep_keys: Container[str]):
+        """Remove keys from document except for the keys given.
+
+        :param keep_keys: Keys to keep.
+        :return: Updated document.
+        """
+        delete_keys = [k for k in self.keys() if k not in keep_keys]
+        for delete_key in delete_keys:
+            del self[delete_key]
         return self
+
+    def delete_unused_keys(self):
+        """Remove keys never written or updated after initialization.
+
+        :return: Updated document.
+        """
+        return self.delete_keys_except(self._touched_keys)
 
     def transform_keys_values(self, mappings: Mapping[str, Callable[[Any], Mapping[str, Any]]],
                               ignore_key_error: bool = False) -> 'TransformDoc':


### PR DESCRIPTION
- Implement `TransformDoc` class which is a dictionary with helper methods to quickly transform documents
- Update `CrawlerESUploader` to use `TransformDoc`
- Removed `DataTransform`
- Update `pmid_to_funding` and `pmid_to_citation` so that they properly timeout
- Workaround in `DataReindex` to use smaller scroll size to avoid search context timing out
- Rewrote ImmPort and NCBIGeo uploaders to use `CrawlerESUploader`