### PR TITLE
edit zenodo crawler/uploader to use persistent ids

### DIFF
--- a/crawler/upload/zenodo_covid.py
+++ b/crawler/upload/zenodo_covid.py
@@ -88,5 +88,8 @@ class ZenodoCovidUploader(CrawlerESUploader):
         return doc
 
     def extract_id(self, doc):
-
-        return 'zenodo.' + doc.pop('_id').split('.')[-1]
+        if 'conceptrecid' in doc:
+            bareid = doc['conceptrecid']
+            return 'zenodo.'+bareid
+        else:
+            return 'zenodo.' + doc.pop('_id').split('.')[-1]


### PR DESCRIPTION
Zenodo assigns an identifier to each version of a dataset as well as a persistent identifier that will point to the latest version. Rather than using the version-based id which changes constantly, use the persistent identifier whenever available